### PR TITLE
Build wheels for macOS arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,8 @@ jobs:
         env:
           CIBW_SKIP: "*-win32 *-manylinux_i686"  # Skip 32 bit
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_TEST_SKIP: "*-macosx_arm64"
           CIBW_TEST_REQUIRES: "pytest"
           # Simple tests that requires the project to be build correctly
           CIBW_TEST_COMMAND_LINUX: >-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ version 0.3.0-dev
   improvements and changes with regards to the compression levels. For full
   details checkout the `zlib-ng 2.1.2 release notes
   <https://github.com/zlib-ng/zlib-ng/releases/tag/2.1.2>`_.
++ Build wheels for macOS arm64.
 
 version 0.2.0
 -----------------


### PR DESCRIPTION
Modify cibuildwheel config to build macOS arm64 wheels as well.
Added `CIBW_TEST_SKIP` as those cannot be tested in CI environments currently due to the lack of arm runners.

https://cibuildwheel.readthedocs.io/en/stable/options/#archs

