### PR TITLE
Replace internal API _PyBytes_Join, removed in Python 3.13

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 0.5.0-dev
+-----------------
++ Fix compatibility with Python 3.13
+
 version 0.4.0
 -----------------
 + Add a ``gzip_ng_threaded`` module that contains the ``gzip_ng_threaded.open``

--- a/src/zlib_ng/zlib_ngmodule.c
+++ b/src/zlib_ng/zlib_ngmodule.c
@@ -2810,7 +2810,7 @@ GzipReader_readall(GzipReader *self, PyObject *Py_UNUSED(ignore))
         Py_DECREF(chunk_list);
         return NULL;
     }
-    PyObject *ret = _PyBytes_Join(empty_bytes, chunk_list);
+    PyObject *ret = PyObject_CallMethod(empty_bytes, "join", "O", chunk_list);
     Py_DECREF(empty_bytes);
     Py_DECREF(chunk_list);
     return ret;


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

I know that the `regex` package wrote a somewhat nontrivial replacement routine in https://github.com/mrabarnett/mrab-regex/commit/bc73ebb5d794668fe272c6f869cfa01add91ed83, but this call happens only once at the end of `GzipReader_readall`, so I expect any added overhead should be negligible. Similarly, we could have used something like `PyObject_CallMethodObjArgs`, but that would have required us to build a `PyObject` containing the method name. In a quick test, I didn’t observe any change in the overall time required to run the test suite.

Fixes https://github.com/pycompression/python-zlib-ng/issues/30.