### PR TITLE
Fix large file decompression bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 0.5.0-dev
+-----------------
++ Fix a bug where files larger than 4GB could not be decompressed.
+
 version 0.4.2
 -----------------
 + Fix a reference counting error that happened on module initialization and

--- a/src/zlib_ng/zlib_ngmodule.c
+++ b/src/zlib_ng/zlib_ngmodule.c
@@ -2592,7 +2592,7 @@ GzipReader_read_into_buffer(GzipReader *self, uint8_t *out_buffer, size_t out_bu
                     uint32_t length = load_u32_le(current_pos);
                     current_pos += 4;
                     // ISIZE is the length of the original data modulo 2^32
-                    if (length != 0xFFFFFFFFUL & self->zst.total_out) {
+                    if (length != (0xFFFFFFFFUL & self->zst.total_out)) {
                         Py_BLOCK_THREADS;
                         PyErr_SetString(BadGzipFile, "Incorrect length of data produced");
                         return -1;

--- a/src/zlib_ng/zlib_ngmodule.c
+++ b/src/zlib_ng/zlib_ngmodule.c
@@ -2590,12 +2590,11 @@ GzipReader_read_into_buffer(GzipReader *self, uint8_t *out_buffer, size_t out_bu
                         return -1;
                     }
                     uint32_t length = load_u32_le(current_pos);
-                    current_pos += 4; 
-                    if (length != (uint32_t)self->zst.total_out) {
+                    current_pos += 4;
+                    // ISIZE is the length of the original data modulo 2^32
+                    if (length != 0xFFFFFFFFUL & self->zst.total_out) {
                         Py_BLOCK_THREADS;
-                        PyErr_Format(BadGzipFile, 
-                            "Incorrect length of data produced. ISIZE: %u, actual size mod 2^32: %u",
-                            length, (uint32_t)self->zst.total_out);
+                        PyErr_SetString(BadGzipFile, "Incorrect length of data produced");
                         return -1;
                     }
                     self->stream_phase = GzipReader_NULL_BYTES;

--- a/src/zlib_ng/zlib_ngmodule.c
+++ b/src/zlib_ng/zlib_ngmodule.c
@@ -2591,9 +2591,11 @@ GzipReader_read_into_buffer(GzipReader *self, uint8_t *out_buffer, size_t out_bu
                     }
                     uint32_t length = load_u32_le(current_pos);
                     current_pos += 4; 
-                    if (length != self->zst.total_out) {
+                    if (length != (uint32_t)self->zst.total_out) {
                         Py_BLOCK_THREADS;
-                        PyErr_SetString(BadGzipFile, "Incorrect length of data produced");
+                        PyErr_Format(BadGzipFile, 
+                            "Incorrect length of data produced. ISIZE: %u, actual size mod 2^32: %u",
+                            length, (uint32_t)self->zst.total_out);
                         return -1;
                     }
                     self->stream_phase = GzipReader_NULL_BYTES;

--- a/tests/test_gzip_ng.py
+++ b/tests/test_gzip_ng.py
@@ -294,12 +294,18 @@ def test_decompress_incorrect_length():
 
 def test_decompress_on_long_input():
     # Ensure that a compressed payload with length bigger than 2**32 (ISIZE is overflown)
-    # can be decompressed.
+    # can be decompressed. To avoid writing the whole uncompressed payload into memory,
+    # the test writes the compressed data in chunks. The payload consists almost exclusively
+    # of zeros to achieve an exteremely efficient compression rate, so that the compressed
+    # data also fits in memory.
+    
     buffered_stream = io.BytesIO()
     n = 20
     block_size = 2**n
     iterations = 2**(32 - n)
-    zeros_block = b"\x00" * block_size
+    zeros_block = bytes(block_size)
+
+    # To avoid writing the whole compressed data, we will write the compressed data
     with gzip_ng.open(buffered_stream, "wb") as gz:
         for _ in range(iterations):
             gz.write(zeros_block)

--- a/tests/test_gzip_ng.py
+++ b/tests/test_gzip_ng.py
@@ -293,12 +293,12 @@ def test_decompress_incorrect_length():
 
 
 def test_decompress_on_long_input():
-    # Ensure that a compressed payload with length bigger than 2**32 (ISIZE is overflown)
-    # can be decompressed. To avoid writing the whole uncompressed payload into memory,
-    # the test writes the compressed data in chunks. The payload consists almost exclusively
-    # of zeros to achieve an exteremely efficient compression rate, so that the compressed
-    # data also fits in memory.
-    
+    # Ensure that a compressed payload with length bigger than 2**32 (ISIZE is
+    # overflown) can be decompressed. To avoid writing the whole uncompressed payload
+    # into memory, the test writes the compressed data in chunks. The payload consists
+    # almost exclusively of zeros to achieve an exteremely efficient compression rate,
+    # so that the compressed data also fits in memory.
+
     buffered_stream = io.BytesIO()
     n = 20
     block_size = 2**n


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

The [ISIZE](https://datatracker.ietf.org/doc/html/rfc1952) field is specified to hold the size the original (uncompressed) file modulo 2^32 (since there are only 32 bits available for this field). This means that when a file larger than 4GB is compressed, `ISIZE` does not actually hold the file size. However, when handling the gzip trailer, the code compares the total output size with the `ISIZE` field directly (without truncating higher order bits), which only works if `size_t` (as the data type that is used to hold the `total_out` variable) is also 32 bits long, which is not the case in general.