### PR TITLE
Use values of READ and WRITE from the gzip module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 0.5.0-dev
+-----------------
++ Fix a bug where READ and WRITE in zlib_ng.gzip_ng were inconsistent with the
+  values in gzip on Python 3.13
+
 version 0.4.3
 -----------------
 + Fix a bug where files larger than 4GB could not be decompressed.

--- a/src/zlib_ng/gzip_ng.py
+++ b/src/zlib_ng/gzip_ng.py
@@ -41,7 +41,7 @@ _COMPRESS_LEVEL_BEST = zlib_ng.Z_BEST_COMPRESSION
 READ_BUFFER_SIZE = 512 * 1024
 
 FTEXT, FHCRC, FEXTRA, FNAME, FCOMMENT = 1, 2, 4, 8, 16
-READ, WRITE = 1, 2
+READ, WRITE = gzip.READ, gzip.WRITE
 
 BadGzipFile = gzip.BadGzipFile  # type: ignore
 


### PR DESCRIPTION
These changed from integers to mode strings in Python 3.13, and we need to remain consistent with the standard library.

Fixes #44.

Reference:
https://docs.python.org/3.13/library/gzip.html#gzip.GzipFile.mode


### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
