### PR TITLE
Fixdeadlock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,6 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
-version 0.5.1
------------------
-+ Fix a bug where ``gzip_ng_threaded.open`` could
-  cause a hang when the program exited and the program was not used with a
-  context manager.
-
 version 0.5.0
 -----------------
 + Wheels are now build for MacOS arm64 architectures.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 0.5.1-dev
+-----------------
++ Threaded reading and writing do no longer block exiting when an exception
+  occurs in the main thread.
+
 version 0.5.0
 -----------------
 + Wheels are now build for MacOS arm64 architectures.

--- a/src/zlib_ng/gzip_ng_threaded.py
+++ b/src/zlib_ng/gzip_ng_threaded.py
@@ -98,8 +98,7 @@ class _ThreadedGzipReader(io.RawIOBase):
         self.exception = None
         self.buffer = io.BytesIO()
         self.block_size = block_size
-        # Using a daemon thread prevents programs freezing on error.
-        self.worker = threading.Thread(target=self._decompress, daemon=True)
+        self.worker = threading.Thread(target=self._decompress)
         self._closed = False
         self.running = True
         self.worker.start()
@@ -232,10 +231,9 @@ class _ThreadedGzipWriter(io.RawIOBase):
                 queue.Queue(queue_size) for _ in range(threads)]
             self.output_queues: List[queue.Queue[Tuple[bytes, int, int]]] = [
                 queue.Queue(queue_size) for _ in range(threads)]
-            # Using daemon threads prevents a program freezing on error.
-            self.output_worker = threading.Thread(target=self._write, daemon=True)
+            self.output_worker = threading.Thread(target=self._write)
             self.compression_workers = [
-                threading.Thread(target=self._compress, args=(i,), daemon=True)
+                threading.Thread(target=self._compress, args=(i,))
                 for i in range(threads)
             ]
         elif threads == 1:
@@ -243,7 +241,7 @@ class _ThreadedGzipWriter(io.RawIOBase):
             self.output_queues = []
             self.compression_workers = []
             self.output_worker = threading.Thread(
-                target=self._compress_and_write, daemon=True)
+                target=self._compress_and_write)
         else:
             raise ValueError(f"threads should be at least 1, got {threads}")
         self.threads = threads

--- a/src/zlib_ng/gzip_ng_threaded.py
+++ b/src/zlib_ng/gzip_ng_threaded.py
@@ -98,9 +98,11 @@ class _ThreadedGzipReader(io.RawIOBase):
         self.exception = None
         self.buffer = io.BytesIO()
         self.block_size = block_size
-        self.worker = threading.Thread(target=self._decompress)
+        # Using a daemon thread prevents programs freezing on error.
+        self.worker = threading.Thread(target=self._decompress, daemon=True)
         self._closed = False
-        self.running = False
+        self.running = True
+        self.worker.start()
 
     def _check_closed(self, msg=None):
         if self._closed:
@@ -124,19 +126,8 @@ class _ThreadedGzipReader(io.RawIOBase):
                 except queue.Full:
                     pass
 
-    def _start(self):
-        if not self.running:
-            self.running = True
-            self.worker.start()
-
-    def _stop(self):
-        if self.running:
-            self.running = False
-            self.worker.join()
-
     def readinto(self, b):
         self._check_closed()
-        self._start()
         result = self.buffer.readinto(b)
         if result == 0:
             while True:
@@ -164,7 +155,8 @@ class _ThreadedGzipReader(io.RawIOBase):
     def close(self) -> None:
         if self._closed:
             return
-        self._stop()
+        self.running = False
+        self.worker.join()
         self.fileobj.close()
         if self.closefd:
             self.raw.close()
@@ -240,9 +232,10 @@ class _ThreadedGzipWriter(io.RawIOBase):
                 queue.Queue(queue_size) for _ in range(threads)]
             self.output_queues: List[queue.Queue[Tuple[bytes, int, int]]] = [
                 queue.Queue(queue_size) for _ in range(threads)]
-            self.output_worker = threading.Thread(target=self._write)
+            # Using daemon threads prevents a program freezing on error.
+            self.output_worker = threading.Thread(target=self._write, daemon=True)
             self.compression_workers = [
-                threading.Thread(target=self._compress, args=(i,))
+                threading.Thread(target=self._compress, args=(i,), daemon=True)
                 for i in range(threads)
             ]
         elif threads == 1:
@@ -250,7 +243,7 @@ class _ThreadedGzipWriter(io.RawIOBase):
             self.output_queues = []
             self.compression_workers = []
             self.output_worker = threading.Thread(
-                target=self._compress_and_write)
+                target=self._compress_and_write, daemon=True)
         else:
             raise ValueError(f"threads should be at least 1, got {threads}")
         self.threads = threads
@@ -261,6 +254,7 @@ class _ThreadedGzipWriter(io.RawIOBase):
         self.raw, self.closefd = open_as_binary_stream(filename, mode)
         self._closed = False
         self._write_gzip_header()
+        self.start()
 
     def _check_closed(self, msg=None):
         if self._closed:
@@ -283,24 +277,21 @@ class _ThreadedGzipWriter(io.RawIOBase):
         self.raw.write(struct.pack(
             "BBBBIBB", magic1, magic2, method, flags, mtime, os, xfl))
 
-    def _start(self):
-        if not self.running:
-            self.running = True
-            self.output_worker.start()
-            for worker in self.compression_workers:
-                worker.start()
+    def start(self):
+        self.running = True
+        self.output_worker.start()
+        for worker in self.compression_workers:
+            worker.start()
 
     def stop(self):
         """Stop, but do not care for remaining work"""
-        if self.running:
-            self.running = False
-            for worker in self.compression_workers:
-                worker.join()
-            self.output_worker.join()
+        self.running = False
+        for worker in self.compression_workers:
+            worker.join()
+        self.output_worker.join()
 
     def write(self, b) -> int:
         self._check_closed()
-        self._start()
         with self.lock:
             if self.exception:
                 raise self.exception

--- a/tests/test_gzip_ng_threaded.py
+++ b/tests/test_gzip_ng_threaded.py
@@ -105,7 +105,6 @@ def test_threaded_write_error(threads):
         threads=threads, block_size=8 * 1024)
     # Bypass the write method which should not allow blocks larger than
     # block_size.
-    f._start()
     f.input_queues[0].put((os.urandom(1024 * 64), b""))
     with pytest.raises(OverflowError) as error:
         f.close()


### PR DESCRIPTION
While True and self.running checks are augmented by a check that checks if the thread that opened the threaded file is still alive. If not, it can never properly call to close.

### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

@y5c4l3 I liked your solution, but this solution is more minimal and also works when the error is thrown when the object is already been written to (and the threads are started). I reverted your solution and my initial solution using git revert, so you will still get commit credit. Thanks for helping to tackle this problem.