### PR TITLE
Add windows arm64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
             {project}/tests/test_gzip_ng.py
           # Windows does not have the test module in the included python.
           # Run compatibility tests instead.
-          CIBW_BEFORE_BUILD_WINDOWS: "Get-ChildItem env:* | sort-object name"
+          CIBW_BEFORE_BUILD_WINDOWS: "SET"
           CIBW_TEST_COMMAND_WINDOWS: >-
             pytest {project}/tests/test_compat.py
             {project}/tests/test_gzip_ng.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,7 @@ jobs:
             {project}/tests/test_gzip_ng.py
           # Windows does not have the test module in the included python.
           # Run compatibility tests instead.
+          CIBW_BEFORE_BUILD_WINDOWS: "gci env:* | sort-object name"
           CIBW_TEST_COMMAND_WINDOWS: >-
             pytest {project}/tests/test_compat.py
             {project}/tests/test_gzip_ng.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - develop
       - main
+      - win-arm64
     tags:
       - "*"
 
@@ -69,6 +70,8 @@ jobs:
             python-version: "3.10"
           - os: "windows-latest"
             python-version: "3.10"
+          - os: "windows-11-arm"
+            python-version: "3.11"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -155,14 +158,14 @@ jobs:
           PYTHON_ZLIB_NG_LINK_DYNAMIC: True
 
   deploy:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ${{ matrix.os }}
     needs:
       - lint
       - package-checks
-      - test-static
-      - test-dynamic
-      - test-arch
+      # - test-static
+      # - test-dynamic
+      # - test-arch
     strategy:
       matrix:
         os:
@@ -170,6 +173,7 @@ jobs:
           - macos-13
           - macos-latest
           - windows-latest
+          - windows-11-arm
         cibw_archs_linux: ["x86_64"]
         build_sdist: [true]
         include:
@@ -235,17 +239,17 @@ jobs:
         with:
           name: "dist-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cibw_archs_linux }}"
           path: "dist/"
-      - name: Publish package to TestPyPI
-        # pypa/gh-action-pypi-publish@master does not work on OSX
-        # Alpha, Beta and dev releases contain a - in the tag.
-        if: contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')
-        run: twine upload --skip-existing -r testpypi dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      - name: Publish package to PyPI
-        if: "!contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')"
-        run: twine upload --skip-existing dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Publish package to TestPyPI
+      #   # pypa/gh-action-pypi-publish@master does not work on OSX
+      #   # Alpha, Beta and dev releases contain a - in the tag.
+      #   if: contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')
+      #   run: twine upload --skip-existing -r testpypi dist/*
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      # - name: Publish package to PyPI
+      #   if: "!contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')"
+      #   run: twine upload --skip-existing dist/*
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - develop
       - main
-      - win-arm64
     tags:
       - "*"
 
@@ -160,14 +159,14 @@ jobs:
           PYTHON_ZLIB_NG_LINK_DYNAMIC: True
 
   deploy:
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ${{ matrix.os }}
     needs:
       - lint
       - package-checks
-      # - test-static
-      # - test-dynamic
-      # - test-arch
+      - test-static
+      - test-dynamic
+      - test-arch
     strategy:
       matrix:
         os:
@@ -247,17 +246,17 @@ jobs:
         with:
           name: "dist-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cibw_archs_linux }}"
           path: "dist/"
-      # - name: Publish package to TestPyPI
-      #   # pypa/gh-action-pypi-publish@master does not work on OSX
-      #   # Alpha, Beta and dev releases contain a - in the tag.
-      #   if: contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')
-      #   run: twine upload --skip-existing -r testpypi dist/*
-      #   env:
-      #     TWINE_USERNAME: __token__
-      #     TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      # - name: Publish package to PyPI
-      #   if: "!contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')"
-      #   run: twine upload --skip-existing dist/*
-      #   env:
-      #     TWINE_USERNAME: __token__
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package to TestPyPI
+        # pypa/gh-action-pypi-publish@master does not work on OSX
+        # Alpha, Beta and dev releases contain a - in the tag.
+        if: contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')
+        run: twine upload --skip-existing -r testpypi dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      - name: Publish package to PyPI
+        if: "!contains(github.ref, '-') && startsWith(github.ref, 'refs/tags')"
+        run: twine upload --skip-existing dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Set MSVC developer prompt
         uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
+        with:
+          arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
       - name: Install build dependencies (MacOS)
         run: brew install make
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
             {project}/tests/test_gzip_ng.py
           # Windows does not have the test module in the included python.
           # Run compatibility tests instead.
-          CIBW_BEFORE_BUILD_WINDOWS: "gci env:* | sort-object name"
+          CIBW_BEFORE_BUILD_WINDOWS: "Get-ChildItem env:* | sort-object name"
           CIBW_TEST_COMMAND_WINDOWS: >-
             pytest {project}/tests/test_compat.py
             {project}/tests/test_gzip_ng.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0  # Fetch everything to get accurately versioned tag.
-      - if: ${{ matix.os == 'windows-11-arm' }}
+      - if: ${{ matrix.os == 'windows-11-arm' }}
         uses: actions/setup-python@v5
         name: Install Python
-      - if: ${{ matix.os != 'windows-11-arm' }}
+      - if: ${{ matrix.os != 'windows-11-arm' }}
         uses: actions/setup-python@v2 # Some issues where caused by higher versions.
         name: Install Python
       - name: Install cibuildwheel twine build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,11 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0  # Fetch everything to get accurately versioned tag.
-      - uses: actions/setup-python@v2 # Some issues where caused by higher versions.
+      - if: ${{ matix.os == 'windows-11-arm' }}
+        uses: actions/setup-python@v5
+        name: Install Python
+      - if: ${{ matix.os != 'windows-11-arm' }}
+        uses: actions/setup-python@v2 # Some issues where caused by higher versions.
         name: Install Python
       - name: Install cibuildwheel twine build
         run: python -m pip install cibuildwheel twine build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,8 @@ jobs:
       - name: Set MSVC developer prompt
         uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
+        with:
+          arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
       - name: Set up QEMU
         if: ${{runner.os == 'Linux' && matrix.cibw_archs_linux == 'aarch64'}}
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,6 @@ jobs:
             {project}/tests/test_gzip_ng.py
           # Windows does not have the test module in the included python.
           # Run compatibility tests instead.
-          CIBW_BEFORE_BUILD_WINDOWS: "SET"
           CIBW_TEST_COMMAND_WINDOWS: >-
             pytest {project}/tests/test_compat.py
             {project}/tests/test_gzip_ng.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
         run: cibuildwheel --output-dir dist
         env:
           # Skip 32 bit, macosx_arm64 causes issues on cpython 3.9
-          CIBW_SKIP: "*-win32 *-manylinux_i686 cp38-macosx_arm64"
+          CIBW_SKIP: "*-win32 *-manylinux_i686 cp38-macosx_arm64 cp39-win_arm64 cp310-win_arm64"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_TEST_REQUIRES: "pytest"
           # Simple tests that requires the project to be build correctly

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 1.0.1-dev
+-----------------
++ Wheels are now built for Windows arm64 architectures.
+
 version 1.0.0
 -----------------
 The library has been running without issues as a dependency in quite a few


### PR DESCRIPTION
Closes #72 

This would add wheel builds for arm64 windows as well as arm64 windows tests to the `test-static` job.

### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [x] Documentation was updated (if needed)
