### PR TITLE
ci: re-enable PyPy wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,7 @@ jobs:
       - name: Build wheels
         run: cibuildwheel --output-dir dist
         env:
+          CIBW_ENABLE: "pypy"
           # Skip 32 bit, macosx_arm64 causes issues on cpython 3.9
           CIBW_SKIP: "*-win32 *-manylinux_i686 cp38-macosx_arm64 cp39-win_arm64 cp310-win_arm64"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 version 1.0.1-dev
 -----------------
 + Wheels are now built for Windows arm64 architectures.
++ Restore PyPy wheel builds.
 
 version 1.0.0
 -----------------


### PR DESCRIPTION
Hey @rhpvorderman - same story as https://github.com/pycompression/python-isal/pull/251 :)

Quick fix to patch #78 , and let me know if you'd like a migration to [pypa/cibuildwheel](https://github.com/pypa/cibuildwheel)